### PR TITLE
Added ca:// prefix to SLAC LLRF pages

### DIFF
--- a/PIP-II/LLRF/scrf/rf_ssr2_main.bob
+++ b/PIP-II/LLRF/scrf/rf_ssr2_main.bob
@@ -178,7 +178,7 @@
         <description>Open Display</description>
         <file>rf_srf_wf_cavity_all_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -214,7 +214,7 @@
         <description>Cavity 1</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>1</C>
           <RFS>1A</RFS>
         </macros>
@@ -224,7 +224,7 @@
         <description>Cavity 2</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>2</C>
           <RFS>1A</RFS>
         </macros>
@@ -234,7 +234,7 @@
         <description>Cavity 3</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>3</C>
           <RFS>2A</RFS>
         </macros>
@@ -244,7 +244,7 @@
         <description>Cavity 4</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>4</C>
           <RFS>2A</RFS>
         </macros>
@@ -254,7 +254,7 @@
         <description>Cavity 5</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>5</C>
           <RFS>1B</RFS>
         </macros>
@@ -264,7 +264,7 @@
         <description>Cavity 6</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>6</C>
           <RFS>1B</RFS>
         </macros>
@@ -274,7 +274,7 @@
         <description>Cavity 7</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>7</C>
           <RFS>2B</RFS>
         </macros>
@@ -284,7 +284,7 @@
         <description>Cavity 8</description>
         <file>rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>8</C>
           <RFS>2B</RFS>
         </macros>
@@ -317,7 +317,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>1</C>
           <RFS>1A</RFS>
           <R>A</R>
@@ -377,7 +377,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>2</C>
           <RFS>1A</RFS>
           <R>A</R>
@@ -437,7 +437,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>3</C>
           <RFS>2A</RFS>
           <R>A</R>
@@ -497,7 +497,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>4</C>
           <RFS>2A</RFS>
           <R>A</R>
@@ -557,7 +557,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>5</C>
           <RFS>1B</RFS>
           <R>B</R>
@@ -617,7 +617,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>6</C>
           <RFS>1B</RFS>
           <R>B</R>
@@ -677,7 +677,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>7</C>
           <RFS>2B</RFS>
           <R>B</R>
@@ -737,7 +737,7 @@
         <description>Open Display</description>
         <file>rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>8</C>
           <RFS>2B</RFS>
           <R>B</R>
@@ -792,7 +792,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>EDM activeXTextClass</name>
-    <text>SSR2:TEST:0100</text>
+    <text>ca://SSR2:TEST:0100</text>
     <x>96</x>
     <y>200</y>
     <width>113</width>
@@ -1037,10 +1037,10 @@ Status</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>rf_srf_ssa_cm_7kW.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -1133,7 +1133,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0110:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0110:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>360</y>
     <width>13</width>
@@ -1185,7 +1185,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0120:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0120:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>380</y>
     <width>13</width>
@@ -1281,7 +1281,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0130:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0130:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>400</y>
     <width>13</width>
@@ -1333,7 +1333,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0140:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0140:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>420</y>
     <width>13</width>
@@ -1429,7 +1429,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0150:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0150:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>440</y>
     <width>13</width>
@@ -1481,7 +1481,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0160:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0160:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>460</y>
     <width>13</width>
@@ -1577,7 +1577,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0170:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0170:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>480</y>
     <width>13</width>
@@ -1629,7 +1629,7 @@ Status</text>
   </widget>
   <widget type="multi_state_led" version="2.0.0">
     <name>EDM activeRectangleClass</name>
-    <pv_name>=highestSeverity(`SSR2:TEST:0180:SSA:WtrLeakStat.SEVR`)</pv_name>
+    <pv_name>=highestSeverity(`ca://SSR2:TEST:0180:SSA:WtrLeakStat.SEVR`)</pv_name>
     <x>116</x>
     <y>500</y>
     <width>13</width>
@@ -2256,10 +2256,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>rf_srf_hardware_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2287,10 +2287,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>rf_srf_cal_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2318,10 +2318,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>rf_srf_cavity_control_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2354,7 +2354,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0110:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0110:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>296</x>
     <y>580</y>
@@ -2382,7 +2382,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0110:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0110:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>356</x>
     <y>580</y>
@@ -2578,7 +2578,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0120:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0120:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>296</x>
     <y>608</y>
@@ -2606,7 +2606,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0120:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0120:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>356</x>
     <y>608</y>
@@ -2634,7 +2634,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0130:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0130:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>296</x>
     <y>636</y>
@@ -2662,7 +2662,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0130:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0130:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>356</x>
     <y>636</y>
@@ -2690,7 +2690,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0140:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0140:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>296</x>
     <y>664</y>
@@ -2718,7 +2718,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0140:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0140:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>356</x>
     <y>664</y>
@@ -2746,7 +2746,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0150:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0150:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>540</x>
     <y>580</y>
@@ -2774,7 +2774,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0150:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0150:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>600</x>
     <y>580</y>
@@ -2802,7 +2802,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0160:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0160:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>540</x>
     <y>608</y>
@@ -2830,7 +2830,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0160:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0160:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>600</x>
     <y>608</y>
@@ -2858,7 +2858,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0170:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0170:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>540</x>
     <y>636</y>
@@ -2886,7 +2886,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0170:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0170:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>600</x>
     <y>636</y>
@@ -2914,7 +2914,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0180:FLTDATA_STRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0180:FLTDATA_STRT</pv_name>
     <text>Start</text>
     <x>540</x>
     <y>664</y>
@@ -2942,7 +2942,7 @@ is running</text>
         <value>1</value>
       </action>
     </actions>
-    <pv_name>SSR2:TEST:0180:FLTDATA_ABRT</pv_name>
+    <pv_name>ca://SSR2:TEST:0180:FLTDATA_ABRT</pv_name>
     <text>Stop</text>
     <x>600</x>
     <y>664</y>
@@ -3015,7 +3015,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0110:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0110:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3042,7 +3042,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0110:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0110:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3078,7 +3078,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0120:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0120:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3105,7 +3105,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0120:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0120:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3141,7 +3141,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0130:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0130:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3168,7 +3168,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0130:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0130:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3204,7 +3204,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0140:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0140:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3231,7 +3231,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0140:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0140:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3267,7 +3267,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0150:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0150:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3294,7 +3294,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0150:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0150:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3330,7 +3330,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0160:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0160:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3357,7 +3357,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0160:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0160:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3393,7 +3393,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0170:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0170:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3420,7 +3420,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0170:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0170:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3456,7 +3456,7 @@ is running</text>
           <exp bool_exp="true">
             <value>false</value>
           </exp>
-          <pv_name>SSR2:TEST:0180:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0180:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3483,7 +3483,7 @@ is running</text>
           <exp bool_exp="true">
             <value>true</value>
           </exp>
-          <pv_name>SSR2:TEST:0180:FLTDATA_STS</pv_name>
+          <pv_name>ca://SSR2:TEST:0180:FLTDATA_STS</pv_name>
         </rule>
       </rules>
     </widget>
@@ -3517,10 +3517,10 @@ Auto-Save</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>rf_srf_fault_data_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -3546,7 +3546,7 @@ Auto-Save</text>
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>EDM activeXTextDspClass</name>
-    <pv_name>SSR2:TEST:0100:AACTMEANSUM</pv_name>
+    <pv_name>ca://SSR2:TEST:0100:AACTMEANSUM</pv_name>
     <x>616</x>
     <y>80</y>
     <width>84</width>
@@ -3619,7 +3619,7 @@ Turned Off</text>
         <exp bool_exp="true">
           <value>false</value>
         </exp>
-        <pv_name>SSR2:TEST:0100:AACTMEANSUMCALC</pv_name>
+        <pv_name>ca://SSR2:TEST:0100:AACTMEANSUMCALC</pv_name>
       </rule>
     </rules>
   </widget>


### PR DESCRIPTION
Simple search replace of SSR2:TEST with ca://SSR2:TEST, as the LLRF IOC provided by SLAC is apparently using CA (not PVA). This change should make the pages work in time for their visit in a few weeks time, and be straightforward to revert whenever the IOC gets updated to use PVA.

Conveniently, the way the display templates were designed means this only had to be applied to the main page.