### PR TITLE
Temp. addition of ca:// prefix for SSR2 page

### DIFF
--- a/PIP-II/LLRF/rf_ssr2_main.bob
+++ b/PIP-II/LLRF/rf_ssr2_main.bob
@@ -178,7 +178,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_wf_cavity_all_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -214,7 +214,7 @@
         <description>Cavity 1</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>1</C>
           <RFS>1A</RFS>
         </macros>
@@ -224,7 +224,7 @@
         <description>Cavity 2</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>2</C>
           <RFS>1A</RFS>
         </macros>
@@ -234,7 +234,7 @@
         <description>Cavity 3</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>3</C>
           <RFS>2A</RFS>
         </macros>
@@ -244,7 +244,7 @@
         <description>Cavity 4</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>4</C>
           <RFS>2A</RFS>
         </macros>
@@ -254,7 +254,7 @@
         <description>Cavity 5</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>5</C>
           <RFS>1B</RFS>
         </macros>
@@ -264,7 +264,7 @@
         <description>Cavity 6</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>6</C>
           <RFS>1B</RFS>
         </macros>
@@ -274,7 +274,7 @@
         <description>Cavity 7</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>7</C>
           <RFS>2B</RFS>
         </macros>
@@ -284,7 +284,7 @@
         <description>Cavity 8</description>
         <file>scrf/rf_srf_wf_cavity_overview.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>8</C>
           <RFS>2B</RFS>
         </macros>
@@ -317,7 +317,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>1</C>
           <RFS>1A</RFS>
           <R>A</R>
@@ -377,7 +377,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>2</C>
           <RFS>1A</RFS>
           <R>A</R>
@@ -437,7 +437,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>3</C>
           <RFS>2A</RFS>
           <R>A</R>
@@ -497,7 +497,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>4</C>
           <RFS>2A</RFS>
           <R>A</R>
@@ -557,7 +557,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>5</C>
           <RFS>1B</RFS>
           <R>B</R>
@@ -617,7 +617,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>6</C>
           <RFS>1B</RFS>
           <R>B</R>
@@ -677,7 +677,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>7</C>
           <RFS>2B</RFS>
           <R>B</R>
@@ -737,7 +737,7 @@
         <description>Open Display</description>
         <file>scrf/rf_srf_cavity_main.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
           <C>8</C>
           <RFS>2B</RFS>
           <R>B</R>
@@ -792,7 +792,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>EDM activeXTextClass</name>
-    <text>SSR2:TEST:0100</text>
+    <text>ca://SSR2:TEST:0100</text>
     <x>96</x>
     <y>200</y>
     <width>113</width>
@@ -1037,10 +1037,10 @@ Status</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>scrf/rf_srf_ssa_cm_7kW.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2256,10 +2256,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>scrf/rf_srf_hardware_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2287,10 +2287,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>scrf/rf_srf_cal_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -2318,10 +2318,10 @@ is running</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>scrf/rf_srf_cavity_control_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>
@@ -3517,10 +3517,10 @@ Auto-Save</text>
     <name>EDM relatedDisplayClass</name>
     <actions>
       <action type="open_display">
-        <description>SSR2:TEST:0100</description>
+        <description>ca://SSR2:TEST:0100</description>
         <file>scrf/rf_srf_fault_data_cm.bob</file>
         <macros>
-          <CM>SSR2:TEST:01</CM>
+          <CM>ca://SSR2:TEST:01</CM>
         </macros>
         <target>tab</target>
       </action>


### PR DESCRIPTION
Re-did search replace of SSR2:TEST to inject ca:// prefix to temporarily accomodate the use of CA in as-delivered LLRF IOC for SSR2.